### PR TITLE
packaging: distribute type info with package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,11 @@ setup(
     author=pkg['__author__'],
     author_email=pkg['__author_email__'],
     packages=find_packages(),
-    package_data={'': ['LICENSE']},
+    package_data={
+        '': ['LICENSE'],
+        'fastapi_rfc7807': ['py.typed'],
+    },
+    include_package_data=True,
     python_requires='>=3.8',
     install_requires=[
         'fastapi',
@@ -50,5 +54,4 @@ setup(
         'Operating System :: OS Independent',
     ],
     zip_safe=False,
-    include_package_data=True,
 )


### PR DESCRIPTION
This PR:
- adds a py.typed file and corresponding packaging updates  to distribute type info with the package per [PEP 561](https://www.python.org/dev/peps/pep-0561/)