### PR TITLE
maintenance: add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+
+# These owners will be the default owners for everything in the
+# repo. Unless a later match takes precedence, owners listed here
+# will be requested for review when someone opens a pull request.
+*       @edaniszewski
+
+# Order is important; the last matching pattern takes the most
+# precedence. Additional matches may be added below (e.g. *.py
+# for pull requests that only modify Python files).


### PR DESCRIPTION
This PR:
- adds a codeowners file with myself as an owner so I am automatically added to PR  reviews