### PR TITLE
feat: add notion of pre and post hooks around error response generation

### DIFF
--- a/examples/hooks.py
+++ b/examples/hooks.py
@@ -6,17 +6,25 @@ Run from the `examples` directory with:
     $ uvicorn hooks:app
 """
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 
 from fastapi_rfc7807.middleware import register
 
 
-def print_error(request, exc):
+def print_error(request: Request, exc: Exception) -> None:
     print(exc)
 
 
+def add_response_header(request: Request, response: Response, exc: Exception) -> None:
+    response.headers['X-Custom-Header'] = 'foobar'
+
+
 app = FastAPI()
-register(app, hooks=[print_error])
+register(
+    app=app,
+    pre_hooks=[print_error],
+    post_hooks=[add_response_header],
+)
 
 
 @app.get('/error')
@@ -26,7 +34,14 @@ async def error():
 
 # Response:
 #
-# $ curl localhost:8000/error
+# $ curl -i localhost:8000/error
+# HTTP/1.1 200 OK
+# date: Wed, 30 Sep 2020 20:43:32 GMT
+# server: uvicorn
+# content-length: 125
+# content-type: application/problem+json
+# x-custom-header: foobar
+#
 # {"exc_type":"ValueError","type":"about:blank","title":"Unexpected Server Error","status":500,"detail":"something went wrong"}
 
 # In application logs, the error gets printed


### PR DESCRIPTION
This PR:
- adds "post" hooks and differentiates them from the existing  "pre"  hooks.
- post hooks are added here as a convenience to allow things to modify the response as needed prior to sending the response. there may be other ways to do this, but it seems like based on the way  that fastapi/starlette orders and executes middleware, this is the place in the chain where it would need to happen.